### PR TITLE
Fix retry button visibility and restart flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,10 @@
         <div id="ui">
             <div id="score">Score: 0</div>
         </div>
+        <!-- ゲームオーバー時だけ表示するパネル -->
         <div id="gameOver" class="hidden">
             <p>Game Over</p>
+            <!-- リトライ操作用のボタン -->
             <button id="retryButton">Retry</button>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -274,18 +274,21 @@ function gameLoop(timestamp) {
 function triggerGameOver() {
     if (isGameOver) return;
     isGameOver = true;
+    // hidden クラスを外してパネルとリトライボタンを表示する
     gameOverPanel.classList.remove('hidden');
 }
 
 // ゲーム開始時の初期化処理
 function resetGame() {
     isGameOver = false;
+    // 再挑戦時はボタンを隠し、入力状態もリセットする
     gameOverPanel.classList.add('hidden');
     worldOffset = 0;
     score = 0;
     player.y = canvas.height - 120 - player.height;
     player.vy = 0;
     player.onGround = true;
+    spacePressed = false;
     lastTime = null;
     resetTerrain();
     generateTerrain(canvas.width * 2);
@@ -315,6 +318,7 @@ function handleKeyUp(e) {
 document.addEventListener('keydown', handleKeyDown);
 document.addEventListener('keyup', handleKeyUp);
 
+// ゲームオーバー後にリトライすると、初期状態から再開できる
 retryButton.addEventListener('click', () => {
     resetGame();
 });

--- a/style.css
+++ b/style.css
@@ -63,6 +63,15 @@ canvas {
     background: #7dd3fc;
 }
 
+/* 共通で使える非表示用クラス */
 .hidden {
+    display: none;
+}
+
+/*
+ * hidden クラスは #gameOver の display 指定より優先させたいので
+ * セレクターの優先度を合わせて上書きする
+ */
+#gameOver.hidden {
     display: none;
 }


### PR DESCRIPTION
## Summary
- ensure the retry overlay stays hidden until game over by adjusting the hidden class specificity
- reset the game state, including input flags, when retrying and document the UI behavior

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca6d9438a88322a2543b1f0f055d60