### PR TITLE
Add missile items, difficulty scaling, and leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,17 +9,62 @@
 <body>
     <div class="game-wrapper">
         <canvas id="gameCanvas" width="800" height="400"></canvas>
-        <div id="ui">
-            <div id="score">Score: 0</div>
+        <!-- --- hud start --- -->
+        <div id="ui" class="hud">
+            <div id="score">Score: 0 m</div>
+            <div id="effects">Effects: None</div>
         </div>
-        <!-- バージョン表示用のテキスト -->
+        <!-- --- hud end --- -->
+        <!-- --- version start --- -->
         <div id="versionLabel"></div>
-        <!-- ゲームオーバー時だけ表示するパネル -->
-        <div id="gameOver" class="hidden">
-            <p>Game Over</p>
-            <!-- リトライ操作用のボタン -->
-            <button id="retryButton">Retry</button>
+        <!-- --- version end --- -->
+        <!-- --- hud message start --- -->
+        <div id="hudMessage" class="hidden"></div>
+        <!-- --- hud message end --- -->
+        <!-- --- title screen start --- -->
+        <div id="titleScreen" class="overlay">
+            <div class="panel">
+                <h1>Simple Bike Run</h1>
+                <p class="instructions">スペースキー / タップでジャンプ</p>
+                <button id="startButton" class="primary">Start</button>
+                <!-- --- leaderboard start --- -->
+                <div id="leaderboardSection">
+                    <div class="leaderboard-header">
+                        <h2>ランキング</h2>
+                        <button id="clearLeaderboardButton" class="ghost">Clear</button>
+                    </div>
+                    <table id="leaderboardTable">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>名前</th>
+                                <th>スコア</th>
+                                <th>日時</th>
+                            </tr>
+                        </thead>
+                        <tbody id="leaderboardBody">
+                            <tr><td colspan="4" class="empty">記録がありません</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+                <!-- --- leaderboard end --- -->
+            </div>
         </div>
+        <!-- --- title screen end --- -->
+        <!-- --- game over start --- -->
+        <div id="gameOver" class="hidden overlay">
+            <div class="panel">
+                <p class="title">Game Over</p>
+                <div class="score-info">Distance: <span id="finalScore">0</span> m</div>
+                <label class="name-label" for="playerNameInput">名前（空欄可）</label>
+                <input id="playerNameInput" type="text" maxlength="16" placeholder="PLAYER">
+                <div class="save-row">
+                    <button id="saveScoreButton" class="primary">Save Score</button>
+                    <button id="retryButton" class="primary">Retry</button>
+                </div>
+            </div>
+        </div>
+        <!-- --- game over end --- -->
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -2,16 +2,48 @@
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 const scoreLabel = document.getElementById('score');
+const effectsLabel = document.getElementById('effects');
+const hudMessage = document.getElementById('hudMessage');
+const titleScreen = document.getElementById('titleScreen');
+const startButton = document.getElementById('startButton');
 const gameOverPanel = document.getElementById('gameOver');
 const retryButton = document.getElementById('retryButton');
+const saveScoreButton = document.getElementById('saveScoreButton');
+const nameInput = document.getElementById('playerNameInput');
+const finalScoreLabel = document.getElementById('finalScore');
+const leaderboardBody = document.getElementById('leaderboardBody');
+const clearLeaderboardButton = document.getElementById('clearLeaderboardButton');
 const versionLabel = document.getElementById('versionLabel');
 
-const GAME_VERSION = 'v1.1.0'; // --- added for version display ---
+const GAME_VERSION = 'v1.3.0'; // --- version display ---
 if (versionLabel) {
     versionLabel.textContent = GAME_VERSION;
 }
 
-// プレイヤーとゲームの基本設定
+const GameState = {
+    TITLE: 'title',
+    PLAYING: 'playing',
+    GAMEOVER: 'gameover'
+};
+let gameState = GameState.TITLE;
+
+const baseSettings = { // --- base settings start ---
+    gravity: 1800,
+    jumpVelocity: -750,
+    baseWorldSpeed: 220,
+    baseMissileInterval: 0.9,
+    missileSpeed: 640,
+    maxMissiles: 40,
+    messageDuration: 2.4
+};
+const effectCaps = {
+    multiShot: 3,
+    missileIntervalMin: 0.25,
+    speedMultiplierMax: 1.45,
+    shieldMax: 2
+};
+// --- base settings end ---
+
 const player = {
     x: 150,
     y: 0,
@@ -21,31 +53,260 @@ const player = {
     onGround: false
 };
 
-const gravity = 1800;           // 重力加速度 (px/s^2)
-const jumpVelocity = -750;      // ジャンプ初速度
-const worldSpeed = 220;         // 背景スクロール速度
-const segmentCleanupOffset = 600;   // 画面外のセグメントを捨てる範囲
-const maxGroundHeight = 200;    // 地面の最大高さ
-const minGroundHeight = 70;     // 地面の最小高さ
-
 let lastTime = null;
 let worldOffset = 0;
+let currentWorldSpeed = baseSettings.baseWorldSpeed;
 let score = 0;
 let spacePressed = false;
-let isGameOver = false;
+let hudMessageTimer = 0;
 
-// --- added for hazard management ---
-let hazards = [];
-let hazardTimer = 0;
-
-// 地形データを保持する配列
+// --- terrain start ---
 let groundSegments = [];
 let lastSegmentEnd = 0;
+const maxGroundHeight = 200;
+const minGroundHeight = 70;
+// --- terrain end ---
 
-// 地形セグメントの初期化
+// --- hazards start ---
+let hazards = [];
+let hazardTimer = 0;
+// --- hazards end ---
+
+// --- items start ---
+let items = [];
+let itemSpawnTimer = 4;
+// --- items end ---
+
+// --- missiles start ---
+let missiles = [];
+let missileCooldownTimer = baseSettings.baseMissileInterval;
+// --- missiles end ---
+
+// --- effects start ---
+const effectState = {
+    missileEnabled: false,
+    shieldCharges: 0,
+    multiShot: 1,
+    missileInterval: baseSettings.baseMissileInterval,
+    speedMultiplier: 1
+};
+let activeEffects = [];
+// --- effects end ---
+
+// --- difficulty start ---
+let difficultyLevel = 0;
+let difficultyProgress = 0;
+const MAX_DIFFICULTY = 7;
+// --- difficulty end ---
+
+// --- leaderboard start ---
+const storage = (() => {
+    try {
+        const testKey = '__bike_test__';
+        window.localStorage.setItem(testKey, '1');
+        window.localStorage.removeItem(testKey);
+        return window.localStorage;
+    } catch (error) {
+        console.warn('LocalStorage is not available.', error);
+        return null;
+    }
+})();
+
+class Leaderboard {
+    constructor(key, maxEntries = 10) {
+        this.key = key;
+        this.maxEntries = maxEntries;
+        this.cache = null;
+    }
+
+    loadTop(limit = this.maxEntries) {
+        const entries = this._load();
+        return entries.slice(0, limit);
+    }
+
+    addEntry(entry) {
+        const entries = this._load();
+        const safeEntry = {
+            id: entry.id,
+            name: entry.name,
+            score: entry.score,
+            date: entry.date
+        };
+        entries.push(safeEntry);
+        entries.sort((a, b) => {
+            if (b.score !== a.score) return b.score - a.score;
+            return new Date(b.date).getTime() - new Date(a.date).getTime();
+        });
+        while (entries.length > this.maxEntries) {
+            entries.pop();
+        }
+        return this._save(entries);
+    }
+
+    clearAll() {
+        this.cache = [];
+        if (!storage) return false;
+        try {
+            storage.removeItem(this.key);
+            return true;
+        } catch (error) {
+            console.warn('Failed to clear leaderboard.', error);
+            return false;
+        }
+    }
+
+    _load() {
+        if (this.cache) {
+            return [...this.cache];
+        }
+        if (!storage) {
+            this.cache = [];
+            return [];
+        }
+        try {
+            const raw = storage.getItem(this.key);
+            if (!raw) {
+                this.cache = [];
+                return [];
+            }
+            const parsed = JSON.parse(raw);
+            if (!Array.isArray(parsed)) {
+                this.cache = [];
+                return [];
+            }
+            this.cache = parsed.map((entry) => ({
+                id: entry.id,
+                name: entry.name,
+                score: entry.score,
+                date: entry.date
+            }));
+            return [...this.cache];
+        } catch (error) {
+            console.warn('Failed to parse leaderboard data.', error);
+            this.cache = [];
+            return [];
+        }
+    }
+
+    _save(entries) {
+        this.cache = [...entries];
+        if (!storage) return false;
+        try {
+            storage.setItem(this.key, JSON.stringify(entries));
+            return true;
+        } catch (error) {
+            console.warn('Failed to save leaderboard data.', error);
+            return false;
+        }
+    }
+}
+
+const leaderboard = new Leaderboard('bikeGame.leaderboard.v1', 10);
+const LAST_NAME_KEY = 'bikeGame.playerName';
+let latestEntryId = null;
+let lastKnownName = storage ? storage.getItem(LAST_NAME_KEY) || '' : '';
+// --- leaderboard end ---
+
+function generateId() {
+    return `id-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+// --- utility start ---
+function randRange(min, max) {
+    return Math.random() * (max - min) + min;
+}
+
+function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+}
+
+function rectanglesOverlap(a, b) {
+    return (
+        a.x < b.x + b.width &&
+        a.x + a.width > b.x &&
+        a.y < b.y + b.height &&
+        a.y + a.height > b.y
+    );
+}
+// --- utility end ---
+
+function updateScoreDisplay() {
+    scoreLabel.textContent = `Score: ${score} m`;
+}
+
+function updateEffectsDisplay() {
+    const segments = [];
+    if (effectState.missileEnabled) {
+        segments.push(`Msl x${effectState.multiShot}`);
+        if (effectState.missileInterval < baseSettings.baseMissileInterval - 0.05) {
+            segments.push('Rapid');
+        }
+    }
+    if (effectState.shieldCharges > 0) {
+        segments.push(`Shield x${effectState.shieldCharges}`);
+    }
+    if (effectState.speedMultiplier > 1.01) {
+        segments.push('Speed');
+    }
+    effectsLabel.textContent = `Effects: ${segments.length > 0 ? segments.join(' / ') : 'None'}`;
+}
+
+function showHudMessage(message) {
+    hudMessage.textContent = message;
+    hudMessage.classList.remove('hidden');
+    hudMessageTimer = baseSettings.messageDuration;
+}
+
+function updateHudMessage(dt) {
+    if (hudMessageTimer > 0) {
+        hudMessageTimer -= dt;
+        if (hudMessageTimer <= 0) {
+            hudMessageTimer = 0;
+            hudMessage.classList.add('hidden');
+        }
+    }
+}
+
+function recalcTimedEffects() {
+    let multiBonus = 0;
+    let rapidBonus = 0;
+    let speedBonus = 0;
+    activeEffects.forEach((effect) => {
+        if (effect.remaining <= 0) return;
+        if (effect.type === 'multi') multiBonus += effect.value;
+        if (effect.type === 'rapid') rapidBonus += effect.value;
+        if (effect.type === 'speed') speedBonus += effect.value;
+    });
+    effectState.multiShot = clamp(1 + multiBonus, 1, effectCaps.multiShot);
+    effectState.missileInterval = clamp(baseSettings.baseMissileInterval + rapidBonus, effectCaps.missileIntervalMin, baseSettings.baseMissileInterval);
+    effectState.speedMultiplier = clamp(1 + speedBonus, 1, effectCaps.speedMultiplierMax);
+    updateEffectsDisplay();
+}
+
+function addTimedEffect(type, value, duration) {
+    activeEffects.push({ type, value, remaining: duration });
+    recalcTimedEffects();
+}
+
+function updateActiveEffects(dt) {
+    if (gameState !== GameState.PLAYING) return;
+    if (activeEffects.length === 0) return;
+    let changed = false;
+    for (const effect of activeEffects) {
+        effect.remaining -= dt;
+        if (effect.remaining <= 0) {
+            changed = true;
+        }
+    }
+    if (changed) {
+        activeEffects = activeEffects.filter((effect) => effect.remaining > 0);
+        recalcTimedEffects();
+    }
+}
+
+// --- terrain generation start ---
 function resetTerrain() {
     groundSegments = [];
-    // スタート地点は長めの地面を用意
     const initialGround = {
         type: 'ground',
         start: -400,
@@ -56,13 +317,26 @@ function resetTerrain() {
     lastSegmentEnd = initialGround.start + initialGround.width;
 }
 
-// ランダムな数値を返すユーティリティ
-function randRange(min, max) {
-    return Math.random() * (max - min) + min;
+function getTerrainConfig() {
+    const progress = difficultyProgress;
+    const gapChance = clamp(0.22 + progress * 0.3, 0.22, 0.55);
+    const gapMin = 90 + progress * 50;
+    const gapMax = 180 + progress * 110;
+    const groundMin = clamp(160 - progress * 40, 110, 200);
+    const groundMax = clamp(320 - progress * 90, 180, 320);
+    const heightVariance = 60 + progress * 40;
+    return {
+        gapChance,
+        gapMin,
+        gapMax,
+        groundMin,
+        groundMax,
+        heightVariance
+    };
 }
 
-// 次に必要な地形が生成されるように調整
 function generateTerrain(targetX) {
+    const config = getTerrainConfig();
     const lastHeight = () => {
         for (let i = groundSegments.length - 1; i >= 0; i -= 1) {
             if (groundSegments[i].type === 'ground') {
@@ -74,9 +348,8 @@ function generateTerrain(targetX) {
 
     while (lastSegmentEnd < targetX) {
         const prevHeight = lastHeight();
-        // ギャップを追加するかどうか
-        if (Math.random() < 0.3) {
-            const gapWidth = randRange(90, 180);
+        if (Math.random() < config.gapChance) {
+            const gapWidth = randRange(config.gapMin, config.gapMax);
             groundSegments.push({
                 type: 'gap',
                 start: lastSegmentEnd,
@@ -85,10 +358,9 @@ function generateTerrain(targetX) {
             lastSegmentEnd += gapWidth;
         }
 
-        // 次の地面セグメントを生成
-        const groundWidth = randRange(160, 320);
-        let newHeight = prevHeight + randRange(-70, 70);
-        newHeight = Math.max(minGroundHeight, Math.min(maxGroundHeight, newHeight));
+        const groundWidth = randRange(config.groundMin, config.groundMax);
+        let newHeight = prevHeight + randRange(-config.heightVariance, config.heightVariance);
+        newHeight = clamp(newHeight, minGroundHeight, maxGroundHeight);
 
         groundSegments.push({
             type: 'ground',
@@ -100,7 +372,6 @@ function generateTerrain(targetX) {
     }
 }
 
-// 指定したワールド座標にある地面の情報を取得
 function getGroundInfo(worldX) {
     for (const segment of groundSegments) {
         if (worldX >= segment.start && worldX <= segment.start + segment.width) {
@@ -110,126 +381,275 @@ function getGroundInfo(worldX) {
     return null;
 }
 
-function getGroundHeight(worldX) { // --- added for hazard placement ---
+function getGroundHeight(worldX) {
     const info = getGroundInfo(worldX);
     if (info && info.type === 'ground') {
         return info.height;
     }
     return 0;
 }
+// --- terrain generation end ---
 
-// プレイヤーの位置と速度を更新
-function updatePlayer(dt) {
-    if (isGameOver) return;
+// --- difficulty update start ---
+function updateDifficulty() {
+    difficultyLevel = clamp(Math.floor(worldOffset / 1000), 0, MAX_DIFFICULTY);
+    difficultyProgress = clamp(worldOffset / 8000, 0, 1);
+}
 
-    // 速度に重力を適用
-    player.vy += gravity * dt;
-    player.y += player.vy * dt;
+function getHazardParameters() {
+    const interval = clamp(2.2 - difficultyProgress * 1.6, 0.7, 2.2);
+    const baseSpeed = 140 + difficultyProgress * 260;
+    const maxHazards = clamp(2 + Math.floor(difficultyProgress * 5), 2, 6);
+    return { interval, baseSpeed, maxHazards };
+}
 
-    const playerWorldX = player.x + worldOffset + player.width / 2;
-    const groundInfo = getGroundInfo(playerWorldX);
+function getItemInterval() {
+    return clamp(4.5 - difficultyProgress * 2.2, 1.8, 4.5);
+}
 
-    if (groundInfo && groundInfo.type === 'ground') {
-        const groundY = canvas.height - groundInfo.height;
-        if (player.y + player.height >= groundY) {
-            player.y = groundY - player.height;
-            player.vy = 0;
-            player.onGround = true;
-        } else {
-            player.onGround = false;
+function computeWorldSpeed() {
+    const difficultyBoost = difficultyLevel * 18;
+    return (baseSettings.baseWorldSpeed + difficultyBoost) * effectState.speedMultiplier;
+}
+// --- difficulty update end ---
+
+// --- items start ---
+const itemDefinitions = {
+    missile: {
+        id: 'missile',
+        label: 'Missile Core',
+        color: '#3b82f6',
+        apply() {
+            if (!effectState.missileEnabled) {
+                effectState.missileEnabled = true;
+                showHudMessage('Missile Core Online!');
+            } else {
+                addTimedEffect('rapid', -0.08, 8);
+                showHudMessage('Auto Missiles Boost!');
+            }
+            updateEffectsDisplay();
         }
-    } else {
-        // 足場がない → 空中
-        player.onGround = false;
+    },
+    multi: {
+        id: 'multi',
+        label: 'Multi Shot',
+        color: '#f97316',
+        apply() {
+            addTimedEffect('multi', 1, 12);
+            showHudMessage('Multi Shot Up!');
+        }
+    },
+    rapid: {
+        id: 'rapid',
+        label: 'Rapid Fire',
+        color: '#ec4899',
+        apply() {
+            addTimedEffect('rapid', -0.12, 10);
+            showHudMessage('Rapid Fire!');
+        }
+    },
+    shield: {
+        id: 'shield',
+        label: 'Shield',
+        color: '#22d3ee',
+        apply() {
+            effectState.shieldCharges = clamp(effectState.shieldCharges + 1, 0, effectCaps.shieldMax);
+            showHudMessage('Shield +1');
+            updateEffectsDisplay();
+        }
+    },
+    speed: {
+        id: 'speed',
+        label: 'Speed Up',
+        color: '#a3e635',
+        apply() {
+            addTimedEffect('speed', 0.18, 6);
+            showHudMessage('Speed Boost!');
+        }
+    }
+};
+
+function chooseItemDefinition() {
+    const available = Object.values(itemDefinitions).filter((item) => item.id !== 'missile' || !effectState.missileEnabled);
+    const pool = available.length > 0 ? available : Object.values(itemDefinitions);
+    const index = Math.floor(Math.random() * pool.length);
+    return pool[index];
+}
+
+function spawnItem() {
+    const safeSegments = groundSegments.filter((segment) => {
+        if (segment.type !== 'ground') return false;
+        const screenX = segment.start - worldOffset;
+        return screenX > 120 && screenX < canvas.width * 1.3;
+    });
+    if (safeSegments.length === 0) return;
+
+    const segment = safeSegments[Math.floor(Math.random() * safeSegments.length)];
+    const groundY = canvas.height - segment.height;
+    const spawnX = clamp(randRange(segment.start + 30, segment.start + segment.width - 30), segment.start + 30, segment.start + segment.width - 30);
+    const definition = chooseItemDefinition();
+    const item = {
+        id: generateId(),
+        type: definition.id,
+        label: definition.label,
+        color: definition.color,
+        x: spawnX,
+        baseY: groundY - 36,
+        y: groundY - 36,
+        width: 28,
+        height: 28,
+        phase: Math.random() * Math.PI * 2
+    };
+    items.push(item);
+}
+
+function updateItems(dt) {
+    if (gameState !== GameState.PLAYING) return;
+    itemSpawnTimer -= dt;
+    if (itemSpawnTimer <= 0 && items.length < 3) {
+        spawnItem();
+        itemSpawnTimer = getItemInterval() + randRange(1.2, 2.4);
     }
 
-    // 画面外に落ちたらゲームオーバー
-    if (player.y > canvas.height) {
-        triggerGameOver();
+    const playerRect = {
+        x: player.x + worldOffset,
+        y: player.y,
+        width: player.width,
+        height: player.height
+    };
+
+    items = items.filter((item) => {
+        item.phase += dt * 2.2;
+        item.y = item.baseY + Math.sin(item.phase) * 6;
+        const screenX = item.x - worldOffset;
+        if (screenX + item.width < -80) {
+            return false;
+        }
+        if (rectanglesOverlap(playerRect, item)) {
+            const definition = itemDefinitions[item.type];
+            if (definition) {
+                definition.apply();
+            }
+            return false;
+        }
+        return screenX < canvas.width + 80;
+    });
+}
+// --- items end ---
+
+// --- missiles start ---
+function fireMissiles() {
+    missileCooldownTimer = effectState.missileInterval;
+    const shots = Math.max(1, Math.floor(effectState.multiShot));
+    const spread = 14;
+    for (let i = 0; i < shots; i += 1) {
+        const offset = (i - (shots - 1) / 2) * spread;
+        missiles.push({
+            x: player.x + worldOffset + player.width,
+            y: player.y + player.height / 2 + offset,
+            width: 18,
+            height: 6,
+            speed: baseSettings.missileSpeed,
+            life: 0
+        });
+    }
+    if (missiles.length > baseSettings.maxMissiles) {
+        missiles.splice(0, missiles.length - baseSettings.maxMissiles);
     }
 }
 
-// 地形のスクロールやスコアを更新
-function updateWorld(dt) {
-    if (isGameOver) return;
+function updateMissiles(dt) {
+    if (gameState !== GameState.PLAYING) return;
+    if (!effectState.missileEnabled) return;
 
-    worldOffset += worldSpeed * dt;
-    score = Math.floor(worldOffset);
-    scoreLabel.textContent = `Score: ${score}`;
-
-    // 必要な分だけ地形を生成
-    generateTerrain(worldOffset + canvas.width * 2);
-
-    // 画面外の不要なセグメントを削除
-    while (groundSegments.length > 0) {
-        const segment = groundSegments[0];
-        if (segment.start + segment.width < worldOffset - segmentCleanupOffset) {
-            groundSegments.shift();
-        } else {
-            break;
-        }
+    missileCooldownTimer -= dt;
+    if (missileCooldownTimer <= 0) {
+        fireMissiles();
     }
-}
 
-function spawnHazard(baseSpeed, difficultyProgress) { // --- added for hazard creation ---
-    const spawnType = Math.random() < 0.55 ? 'enemy' : 'fireball';
-    const spawnFromLeft = spawnType === 'fireball' && Math.random() < 0.35;
+    missiles = missiles.filter((missile) => {
+        missile.x += missile.speed * dt;
+        missile.life += dt;
+        const missileRect = {
+            x: missile.x,
+            y: missile.y - missile.height / 2,
+            width: missile.width,
+            height: missile.height
+        };
+
+        for (let i = hazards.length - 1; i >= 0; i -= 1) {
+            const hazard = hazards[i];
+            const hazardRect = {
+                x: hazard.x,
+                y: hazard.y,
+                width: hazard.width,
+                height: hazard.height
+            };
+            if (rectanglesOverlap(missileRect, hazardRect)) {
+                hazards.splice(i, 1);
+                return false;
+            }
+        }
+
+        if (missile.x - worldOffset > canvas.width + 120) {
+            return false;
+        }
+        return missile.life < 5;
+    });
+}
+// --- missiles end ---
+
+// --- hazards start ---
+function spawnHazard(params) {
+    const spawnType = Math.random() < 0.6 ? 'enemy' : 'fireball';
     const hazard = {
         type: spawnType,
         width: 36,
         height: 36,
-        direction: spawnFromLeft ? 1 : -1,
-        speed: baseSpeed + randRange(-20, 30)
+        direction: -1,
+        speed: params.baseSpeed + randRange(-20, 40)
     };
-
-    if (spawnFromLeft) {
-        hazard.x = worldOffset - randRange(220, 360);
-        hazard.speed = Math.max(hazard.speed, worldSpeed + 60); // --- added for left spawn balance ---
-    } else {
-        hazard.x = worldOffset + canvas.width + randRange(120, 260);
-    }
 
     if (spawnType === 'enemy') {
         hazard.width = 42;
         hazard.height = 42;
+        hazard.x = worldOffset + canvas.width + randRange(160, 320);
         const groundHeight = getGroundHeight(hazard.x + hazard.width / 2);
         const safeHeight = groundHeight > 0 ? groundHeight : 120;
         hazard.y = canvas.height - safeHeight - hazard.height;
     } else {
-        hazard.width = 30;
-        hazard.height = 30;
-        hazard.baseY = canvas.height - randRange(140, 240);
-        hazard.waveAmplitude = 20 + difficultyProgress * 18;
-        hazard.waveSpeed = 2 + difficultyProgress * 2.5;
-        hazard.phase = 0;
+        hazard.width = 32;
+        hazard.height = 32;
+        const spawnFromLeft = Math.random() < clamp(difficultyProgress, 0.2, 0.5);
+        hazard.direction = spawnFromLeft ? 1 : -1;
+        hazard.speed = clamp(hazard.speed, 160, params.baseSpeed + 120);
+        if (spawnFromLeft) {
+            hazard.x = worldOffset - randRange(260, 360);
+        } else {
+            hazard.x = worldOffset + canvas.width + randRange(140, 280);
+        }
+        hazard.baseY = canvas.height - randRange(150, 240);
+        hazard.waveAmplitude = 22 + difficultyProgress * 22;
+        hazard.waveSpeed = 2 + difficultyProgress * 2.6;
+        hazard.phase = Math.random() * Math.PI * 2;
         hazard.y = hazard.baseY;
+    }
+
+    if (hazard.direction === 1 && hazard.x + hazard.width > player.x + worldOffset - 140) {
+        hazard.x = player.x + worldOffset - 200 - hazard.width;
     }
 
     hazards.push(hazard);
 }
 
-function rectanglesOverlap(a, b) { // --- added for hazard collision ---
-    return (
-        a.x < b.x + b.width &&
-        a.x + a.width > b.x &&
-        a.y < b.y + b.height &&
-        a.y + a.height > b.y
-    );
-}
+function updateHazards(dt) {
+    if (gameState !== GameState.PLAYING) return;
 
-function updateHazards(dt) { // --- added for hazard updates ---
-    if (isGameOver) return;
-
-    const difficultyProgress = Math.min(1, worldOffset / 5000);
-    const intervalRange = 2.6 - difficultyProgress * 1.6;
-    const spawnInterval = Math.max(0.7, intervalRange);
-    const baseSpeed = 80 + difficultyProgress * 220;
-    const maxHazards = Math.min(4, 1 + Math.floor(difficultyProgress * 4));
-
+    const params = getHazardParameters();
     hazardTimer -= dt;
-    if (hazardTimer <= 0 && hazards.length < maxHazards) {
-        spawnHazard(baseSpeed, difficultyProgress);
-        hazardTimer = spawnInterval + randRange(0.25, 0.9);
+    if (hazardTimer <= 0 && hazards.length < params.maxHazards) {
+        spawnHazard(params);
+        hazardTimer = params.interval + randRange(0.2, 0.9);
     }
 
     const playerRect = {
@@ -241,38 +661,86 @@ function updateHazards(dt) { // --- added for hazard updates ---
 
     hazards = hazards.filter((hazard) => {
         if (hazard.type === 'fireball') {
-            hazard.phase += dt;
-            hazard.y = hazard.baseY + Math.sin(hazard.phase * hazard.waveSpeed) * hazard.waveAmplitude;
+            hazard.phase += dt * hazard.waveSpeed;
+            hazard.y = hazard.baseY + Math.sin(hazard.phase) * hazard.waveAmplitude;
         }
 
         hazard.x += hazard.speed * hazard.direction * dt;
 
         if (rectanglesOverlap(playerRect, hazard)) {
+            if (effectState.shieldCharges > 0) {
+                effectState.shieldCharges -= 1;
+                updateEffectsDisplay();
+                showHudMessage('Shield Protected!');
+                return false;
+            }
             triggerGameOver();
+            return false;
         }
 
         const screenX = hazard.x - worldOffset;
-        if (screenX + hazard.width < -220 || screenX > canvas.width + 220) {
-            return false;
-        }
-        return true;
+        return !(screenX + hazard.width < -260 || screenX > canvas.width + 260);
     });
 }
+// --- hazards end ---
 
-// キャンバス上の描画処理
-function draw() {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+// --- player update start ---
+function updatePlayer(dt) {
+    if (gameState !== GameState.PLAYING) return;
 
-    drawBackground();
-    drawTerrain();
-    drawHazards();
-    drawPlayer();
-    drawForeground();
+    player.vy += baseSettings.gravity * dt;
+    player.y += player.vy * dt;
+
+    const playerWorldX = player.x + worldOffset + player.width / 2;
+    const groundInfo = getGroundInfo(playerWorldX);
+    if (groundInfo && groundInfo.type === 'ground') {
+        const groundY = canvas.height - groundInfo.height;
+        if (player.y + player.height >= groundY) {
+            player.y = groundY - player.height;
+            player.vy = 0;
+            player.onGround = true;
+        } else {
+            player.onGround = false;
+        }
+    } else {
+        player.onGround = false;
+    }
+
+    if (player.y > canvas.height) {
+        triggerGameOver();
+    }
 }
+// --- player update end ---
 
-// 空や遠景の演出
+// --- world update start ---
+function updateWorld(dt) {
+    if (gameState !== GameState.PLAYING) return;
+
+    currentWorldSpeed = computeWorldSpeed();
+    worldOffset += currentWorldSpeed * dt;
+    score = Math.floor(worldOffset / 10);
+    updateScoreDisplay();
+
+    updateDifficulty();
+
+    generateTerrain(worldOffset + canvas.width * 2);
+    while (groundSegments.length > 0) {
+        const segment = groundSegments[0];
+        if (segment.start + segment.width < worldOffset - 600) {
+            groundSegments.shift();
+        } else {
+            break;
+        }
+    }
+}
+// --- world update end ---
+
+// --- drawing start ---
 function drawBackground() {
     ctx.fillStyle = '#bae6fd';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = '#8ecae6';
     ctx.fillRect(0, canvas.height - 80, canvas.width, 80);
 
     ctx.strokeStyle = 'rgba(255, 255, 255, 0.2)';
@@ -287,39 +755,45 @@ function drawBackground() {
     }
 }
 
-// 地面の描画
 function drawTerrain() {
-    ctx.fillStyle = '#1b4332';
+    ctx.fillStyle = '#2d6a4f';
     ctx.strokeStyle = '#40916c';
     ctx.lineWidth = 4;
 
     for (const segment of groundSegments) {
+        if (segment.type !== 'ground') continue;
         const screenX = segment.start - worldOffset;
-        if (screenX > canvas.width || screenX + segment.width < -200) {
-            continue;
-        }
-
-        if (segment.type === 'ground') {
-            const groundY = canvas.height - segment.height;
-            ctx.fillStyle = '#2d6a4f';
-            ctx.fillRect(screenX, groundY, segment.width, segment.height);
-
-            // 地面の上面を描く
-            ctx.beginPath();
-            ctx.moveTo(screenX, groundY);
-            ctx.lineTo(screenX + segment.width, groundY);
-            ctx.stroke();
-        }
+        if (screenX > canvas.width || screenX + segment.width < -200) continue;
+        const groundY = canvas.height - segment.height;
+        ctx.fillStyle = '#2d6a4f';
+        ctx.fillRect(screenX, groundY, segment.width, segment.height);
+        ctx.beginPath();
+        ctx.moveTo(screenX, groundY);
+        ctx.lineTo(screenX + segment.width, groundY);
+        ctx.stroke();
     }
 }
 
-function drawHazards() { // --- added for hazard rendering ---
+function drawItems() {
+    for (const item of items) {
+        const screenX = item.x - worldOffset;
+        if (screenX + item.width < -80 || screenX > canvas.width + 80) continue;
+        ctx.fillStyle = item.color;
+        ctx.globalAlpha = 0.92;
+        ctx.fillRect(screenX, item.y, item.width, item.height);
+        ctx.globalAlpha = 1;
+        ctx.strokeStyle = 'rgba(255,255,255,0.65)';
+        ctx.strokeRect(screenX, item.y, item.width, item.height);
+        ctx.fillStyle = 'rgba(15, 23, 42, 0.85)';
+        ctx.font = '12px sans-serif';
+        ctx.fillText(item.label.split(' ')[0], screenX + 4, item.y + item.height / 2 + 4);
+    }
+}
+
+function drawHazards() {
     for (const hazard of hazards) {
         const screenX = hazard.x - worldOffset;
-        if (screenX + hazard.width < -200 || screenX > canvas.width + 200) {
-            continue;
-        }
-
+        if (screenX + hazard.width < -200 || screenX > canvas.width + 200) continue;
         if (hazard.type === 'enemy') {
             ctx.fillStyle = '#ef233c';
             ctx.fillRect(screenX, hazard.y, hazard.width, hazard.height);
@@ -347,25 +821,32 @@ function drawHazards() { // --- added for hazard rendering ---
     }
 }
 
-// プレイヤー（自転車っぽい形）の描画
+function drawMissiles() {
+    ctx.fillStyle = '#38bdf8';
+    for (const missile of missiles) {
+        const screenX = missile.x - worldOffset;
+        if (screenX > canvas.width + 120) continue;
+        ctx.fillRect(screenX, missile.y - missile.height / 2, missile.width, missile.height);
+        ctx.fillStyle = '#f1f5f9';
+        ctx.fillRect(screenX + missile.width - 6, missile.y - missile.height / 2 + 2, 4, missile.height - 4);
+        ctx.fillStyle = '#38bdf8';
+    }
+}
+
 function drawPlayer() {
     const bikeX = player.x;
     const bikeY = player.y;
 
-    // 車体
     ctx.fillStyle = '#ffb703';
     ctx.fillRect(bikeX + 8, bikeY + 10, 24, 12);
-
     ctx.fillStyle = '#fb8500';
     ctx.fillRect(bikeX + 14, bikeY - 2, 12, 18);
 
-    // タイヤ
     ctx.fillStyle = '#023047';
     const wheelRadius = 12;
     drawWheel(bikeX + 10, bikeY + player.height - 4, wheelRadius);
     drawWheel(bikeX + player.width - 10, bikeY + player.height - 4, wheelRadius);
 
-    // ライダー
     ctx.fillStyle = '#ff006e';
     ctx.fillRect(bikeX + 16, bikeY - 12, 12, 12);
     ctx.beginPath();
@@ -385,7 +866,6 @@ function drawWheel(cx, cy, r) {
     ctx.stroke();
 }
 
-// 前景の細かい演出
 function drawForeground() {
     ctx.strokeStyle = 'rgba(255, 255, 255, 0.4)';
     ctx.lineWidth = 1;
@@ -398,53 +878,121 @@ function drawForeground() {
     }
 }
 
-// ゲームループ本体
-function gameLoop(timestamp) {
-    if (!lastTime) lastTime = timestamp;
-    const dt = Math.min((timestamp - lastTime) / 1000, 0.033);
-    lastTime = timestamp;
-
-    updateWorld(dt);
-    updatePlayer(dt);
-    updateHazards(dt);
-    draw();
-
-    requestAnimationFrame(gameLoop);
+function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawBackground();
+    drawTerrain();
+    drawItems();
+    drawHazards();
+    drawMissiles();
+    drawPlayer();
+    drawForeground();
 }
+// --- drawing end ---
 
-// ゲームオーバー処理
-function triggerGameOver() {
-    if (isGameOver) return;
-    isGameOver = true;
-    // hidden クラスを外してパネルとリトライボタンを表示する
-    gameOverPanel.classList.remove('hidden');
-    retryButton.style.display = 'inline-block'; // --- added for retry visibility ---
+// --- leaderboard ui start ---
+function updateLeaderboardDisplay(highlightId = latestEntryId) {
+    if (!leaderboardBody) return;
+    const entries = leaderboard.loadTop(10);
+    leaderboardBody.innerHTML = '';
+    if (entries.length === 0) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 4;
+        cell.textContent = '記録がありません';
+        cell.className = 'empty';
+        row.appendChild(cell);
+        leaderboardBody.appendChild(row);
+        return;
+    }
+
+    entries.forEach((entry, index) => {
+        const row = document.createElement('tr');
+        if (highlightId && entry.id === highlightId) {
+            row.classList.add('highlight');
+        }
+        const rankCell = document.createElement('td');
+        rankCell.textContent = index + 1;
+        const nameCell = document.createElement('td');
+        nameCell.textContent = entry.name || 'PLAYER';
+        const scoreCell = document.createElement('td');
+        scoreCell.textContent = entry.score;
+        const dateCell = document.createElement('td');
+        const date = new Date(entry.date);
+        dateCell.textContent = Number.isNaN(date.getTime()) ? entry.date : date.toLocaleString('ja-JP');
+        row.append(rankCell, nameCell, scoreCell, dateCell);
+        leaderboardBody.appendChild(row);
+    });
 }
+// --- leaderboard ui end ---
 
-// ゲーム開始時の初期化処理
-function resetGame() {
-    isGameOver = false;
-    // 再挑戦時はボタンを隠し、入力状態もリセットする
-    gameOverPanel.classList.add('hidden');
-    retryButton.style.display = 'none'; // --- added for retry visibility ---
+// --- game state start ---
+let hasSavedScore = false;
+
+function prepareNewRun() {
     worldOffset = 0;
+    spacePressed = false;
     score = 0;
+    lastTime = null;
     player.y = canvas.height - 120 - player.height;
     player.vy = 0;
     player.onGround = true;
-    spacePressed = false;
-    lastTime = null;
-    hazards = []; // --- added for hazard reset ---
+    hazards = [];
+    items = [];
+    missiles = [];
+    activeEffects = [];
+    effectState.missileEnabled = false;
+    effectState.shieldCharges = 0;
+    recalcTimedEffects();
+    difficultyLevel = 0;
+    difficultyProgress = 0;
+    currentWorldSpeed = baseSettings.baseWorldSpeed;
     hazardTimer = randRange(1.0, 1.8);
+    missileCooldownTimer = baseSettings.baseMissileInterval;
+    itemSpawnTimer = getItemInterval() + randRange(0.5, 1.5);
+    hudMessageTimer = 0;
+    hudMessage.classList.add('hidden');
+    gameOverPanel.classList.add('hidden');
+    retryButton.style.display = 'none';
+    hasSavedScore = false;
+    if (saveScoreButton) {
+        saveScoreButton.disabled = false;
+    }
+    if (nameInput) {
+        nameInput.value = lastKnownName || '';
+    }
     resetTerrain();
     generateTerrain(canvas.width * 2);
-    scoreLabel.textContent = 'Score: 0';
+    updateScoreDisplay();
+    updateEffectsDisplay();
 }
 
-// 入力イベント
-function attemptJump() { // --- added for mobile/touch jump ---
-    if (player.onGround && !isGameOver) {
-        player.vy = jumpVelocity;
+function beginRun() {
+    prepareNewRun();
+    gameState = GameState.PLAYING;
+}
+
+function triggerGameOver() {
+    if (gameState === GameState.GAMEOVER) return;
+    gameState = GameState.GAMEOVER;
+    gameOverPanel.classList.remove('hidden');
+    retryButton.style.display = 'inline-block';
+    finalScoreLabel.textContent = score;
+    hasSavedScore = false;
+    if (saveScoreButton) {
+        saveScoreButton.disabled = false;
+    }
+    if (nameInput) {
+        nameInput.value = lastKnownName || '';
+    }
+}
+// --- game state end ---
+
+// --- input start ---
+function attemptJump() {
+    if (gameState !== GameState.PLAYING) return;
+    if (player.onGround) {
+        player.vy = baseSettings.jumpVelocity;
         player.onGround = false;
     }
 }
@@ -452,7 +1000,12 @@ function attemptJump() { // --- added for mobile/touch jump ---
 function handleKeyDown(e) {
     if (e.code === 'Space') {
         e.preventDefault();
-        if (!spacePressed) {
+        if (gameState === GameState.TITLE) {
+            titleScreen.classList.add('hidden');
+            beginRun();
+            return;
+        }
+        if (gameState === GameState.PLAYING && !spacePressed) {
             spacePressed = true;
             attemptJump();
         }
@@ -468,16 +1021,92 @@ function handleKeyUp(e) {
 document.addEventListener('keydown', handleKeyDown);
 document.addEventListener('keyup', handleKeyUp);
 
-canvas.addEventListener('touchstart', (e) => { // --- added for touch support ---
+canvas.addEventListener('touchstart', (e) => {
     e.preventDefault();
+    if (gameState === GameState.TITLE) {
+        titleScreen.classList.add('hidden');
+        beginRun();
+        return;
+    }
     attemptJump();
 });
+// --- input end ---
 
-// ゲームオーバー後にリトライすると、初期状態から再開できる
+// --- event bindings start ---
+if (startButton) {
+    startButton.addEventListener('click', () => {
+        titleScreen.classList.add('hidden');
+        beginRun();
+    });
+}
+
 retryButton.addEventListener('click', () => {
-    resetGame();
+    titleScreen.classList.add('hidden');
+    beginRun();
 });
 
-// 初期化してゲームループを開始
-resetGame();
+if (saveScoreButton) {
+    saveScoreButton.addEventListener('click', () => {
+        if (gameState !== GameState.GAMEOVER || hasSavedScore) return;
+        const name = (nameInput?.value || '').trim() || 'PLAYER';
+        const entry = {
+            id: generateId(),
+            name,
+            score,
+            date: new Date().toISOString()
+        };
+        const success = leaderboard.addEntry(entry);
+        if (success) {
+            hasSavedScore = true;
+            latestEntryId = entry.id;
+            if (saveScoreButton) saveScoreButton.disabled = true;
+            if (storage) storage.setItem(LAST_NAME_KEY, name);
+            lastKnownName = name;
+            updateLeaderboardDisplay(latestEntryId);
+            showHudMessage('スコアを保存しました');
+        } else {
+            showHudMessage('保存に失敗しました');
+        }
+    });
+}
+
+if (clearLeaderboardButton) {
+    clearLeaderboardButton.addEventListener('click', () => {
+        if (confirm('ランキングを全て削除しますか？')) {
+            const cleared = leaderboard.clearAll();
+            if (cleared) {
+                latestEntryId = null;
+                updateLeaderboardDisplay();
+                showHudMessage('ランキングをリセットしました');
+            } else {
+                showHudMessage('リセットに失敗しました');
+            }
+        }
+    });
+}
+// --- event bindings end ---
+
+// --- game loop start ---
+function gameLoop(timestamp) {
+    if (!lastTime) lastTime = timestamp;
+    const dt = Math.min((timestamp - lastTime) / 1000, 0.033);
+    lastTime = timestamp;
+
+    updateWorld(dt);
+    updatePlayer(dt);
+    updateActiveEffects(dt);
+    updateItems(dt);
+    updateHazards(dt);
+    updateMissiles(dt);
+    updateHudMessage(dt);
+    draw();
+
+    requestAnimationFrame(gameLoop);
+}
+// --- game loop end ---
+
+// --- initialization start ---
+updateLeaderboardDisplay();
+prepareNewRun();
 requestAnimationFrame(gameLoop);
+// --- initialization end ---

--- a/style.css
+++ b/style.css
@@ -12,6 +12,7 @@ body {
     align-items: center;
     justify-content: center;
     min-height: 100vh;
+    padding: 16px;
 }
 
 .game-wrapper {
@@ -22,75 +23,244 @@ canvas {
     background: linear-gradient(180deg, #6ec6ff 0%, #8de1ff 60%, #e2f6ff 100%);
     border: 4px solid #0d1b2a;
     border-radius: 12px;
+    max-width: 100%;
+    height: auto;
 }
 
-#ui {
-    position: absolute;
-    top: 16px;
-    right: 24px;
-    font-size: 20px;
-    font-weight: bold;
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
-}
-
-#versionLabel {
+/* --- hud start --- */
+.hud {
     position: absolute;
     top: 16px;
     left: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 18px;
+    font-weight: bold;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.45);
+    z-index: 6;
+}
+
+#effects {
+    font-size: 14px;
+    font-weight: 600;
+}
+/* --- hud end --- */
+
+/* --- version start --- */
+#versionLabel {
+    position: absolute;
+    top: 16px;
+    right: 24px;
     font-size: 14px;
     font-weight: bold;
     letter-spacing: 0.04em;
     color: rgba(15, 23, 42, 0.85);
-    background: rgba(255, 255, 255, 0.7);
-    padding: 4px 8px;
+    background: rgba(255, 255, 255, 0.75);
+    padding: 4px 10px;
     border-radius: 8px;
     text-shadow: none;
-    z-index: 6; /* --- added for version visibility --- */
+    z-index: 6;
 }
+/* --- version end --- */
 
-#gameOver {
+/* --- hud message start --- */
+#hudMessage {
+    position: absolute;
+    top: 64px;
+    right: 24px;
+    padding: 8px 14px;
+    background: rgba(15, 23, 42, 0.82);
+    border-radius: 8px;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.45);
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    z-index: 6;
+}
+/* --- hud message end --- */
+
+/* --- overlays start --- */
+.overlay {
     position: absolute;
     inset: 0;
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
-    background: rgba(15, 23, 42, 0.8);
-    gap: 12px;
-    font-size: 32px;
-    letter-spacing: 2px;
+    background: rgba(15, 23, 42, 0.86);
+    z-index: 10;
+    padding: 16px;
+    text-align: center;
 }
 
-#gameOver button {
-    padding: 10px 28px;
-    font-size: 18px;
+.overlay .panel {
+    background: rgba(15, 23, 42, 0.92);
+    padding: 24px;
+    border-radius: 16px;
+    box-shadow: 0 18px 40px rgba(8, 11, 21, 0.6);
+    min-width: min(480px, 90vw);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.overlay.hidden {
+    display: none;
+}
+
+#titleScreen h1 {
+    font-size: 36px;
+    letter-spacing: 4px;
+}
+
+.instructions {
+    font-size: 16px;
+    opacity: 0.85;
+}
+
+button {
     border: none;
-    border-radius: 8px;
+    cursor: pointer;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    transition: transform 0.12s ease, background 0.24s ease, color 0.24s ease;
+    border-radius: 10px;
+    padding: 10px 24px;
+    font-size: 16px;
+}
+
+button.primary {
     background: #38bdf8;
     color: #0f172a;
-    font-weight: bold;
-    cursor: pointer;
-    transition: transform 0.1s ease, background 0.2s ease;
+}
+
+button.primary:hover {
+    background: #7dd3fc;
+    transform: translateY(-2px);
+}
+
+button.ghost {
+    background: transparent;
+    color: #cbd5f5;
+    border: 1px solid rgba(148, 163, 184, 0.6);
+    padding: 6px 16px;
+    font-size: 14px;
+}
+
+button.ghost:hover {
+    background: rgba(148, 163, 184, 0.18);
+    color: #f8fafc;
+}
+
+#leaderboardSection {
+    background: rgba(8, 13, 25, 0.72);
+    border-radius: 12px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-height: 60vh;
+    overflow: auto;
+}
+
+.leaderboard-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+}
+
+#leaderboardTable {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+}
+
+#leaderboardTable th,
+#leaderboardTable td {
+    padding: 6px 8px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    text-align: left;
+}
+
+#leaderboardTable tbody tr.highlight {
+    background: rgba(56, 189, 248, 0.25);
+}
+
+#leaderboardTable tbody tr.highlight td {
+    color: #f8fafc;
+    font-weight: 700;
+}
+
+#leaderboardTable tbody td.empty {
+    text-align: center;
+    color: rgba(226, 232, 240, 0.6);
+    padding: 18px 0;
+}
+
+#gameOver .panel {
+    gap: 12px;
+}
+
+#gameOver .title {
+    font-size: 32px;
+    letter-spacing: 4px;
+}
+
+#gameOver .score-info {
+    font-size: 18px;
+}
+
+#gameOver input {
+    padding: 10px 14px;
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(15, 23, 42, 0.75);
+    color: #f8fafc;
+    text-align: center;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+#gameOver .save-row {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
 }
 
 #retryButton {
-    display: none; /* --- added for retry visibility --- */
+    display: none; /* --- retry visibility --- */
 }
+/* --- overlays end --- */
 
-#gameOver button:hover {
-    transform: translateY(-2px);
-    background: #7dd3fc;
-}
-
-/* 共通で使える非表示用クラス */
 .hidden {
-    display: none;
+    display: none !important;
 }
 
-/*
- * hidden クラスは #gameOver の display 指定より優先させたいので
- * セレクターの優先度を合わせて上書きする
- */
-#gameOver.hidden {
-    display: none;
+@media (max-width: 600px) {
+    canvas {
+        width: min(92vw, 800px);
+    }
+
+    .overlay .panel {
+        min-width: min(360px, 92vw);
+        padding: 20px;
+    }
+
+    button {
+        width: 100%;
+    }
+
+    .hud {
+        left: 16px;
+        font-size: 16px;
+    }
+
+    #versionLabel {
+        right: 16px;
+    }
+
+    #hudMessage {
+        right: 16px;
+    }
 }


### PR DESCRIPTION
## Summary
- add an on-canvas HUD plus title and game-over overlays with leaderboard management UI and retry controls
- introduce collectible power-up items, missile firing, and a local leaderboard with persistent storage
- scale hazards and terrain difficulty by run distance while updating HUD messaging and mobile/touch support

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca71634924832290521a90f606ab6c